### PR TITLE
Add GitHub Actions workflow to sort blocklists

### DIFF
--- a/.github/workflows/sort.yml
+++ b/.github/workflows/sort.yml
@@ -1,0 +1,50 @@
+name: Sort blocklists
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - blocklist
+      - whitelist
+      - src/sort.sh
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Avoid two sorting jobs trying to push simultaneously.
+concurrency:
+  group: sort-blocklists-main
+  cancel-in-progress: false
+
+jobs:
+  sort:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Sort and deduplicate lists
+        run: bash src/sort.sh
+
+      - name: Commit sorted lists
+        shell: bash
+        run: |
+          if git diff --quiet -- blocklist whitelist; then
+            echo "Lists are already sorted."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add blocklist whitelist
+          git commit -m "Sort blocklist and whitelist"
+          git push origin HEAD:main

--- a/.github/workflows/sort.yml
+++ b/.github/workflows/sort.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out main
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
This will create a GitHub action to automatically run sort.sh on commit. Putting as a pull request rather than committing directly since it is more than just a blocklist/whitelist change. @xu-shawn please let me know what you think.